### PR TITLE
Update GZDoom to version 3.4.1

### DIFF
--- a/com.realm667.WolfenDoom_Blade_of_Agony.json
+++ b/com.realm667.WolfenDoom_Blade_of_Agony.json
@@ -22,7 +22,7 @@
 		"/share/man"
 	],
 	"modules": [
-        {
+		{
 			"name": "p7zip",
 			"no-autogen": true,
 			"make-args": ["7z"],
@@ -39,7 +39,7 @@
 				}
 			]
 		},
-        {
+		{
 			"name": "wolfendoom",
 			"buildsystem": "simple",
 			"sources": [
@@ -50,7 +50,7 @@
 				},
 				{
 					"type": "shell",
-					"comment": "7z command taken from build.sh",
+					/* 7z command taken from build.sh */
 					"commands": ["7z a -tzip -mmt=on -mm='Deflate' -mx=9 -ssc -xr@'tools/7zExcludeList.txt' -x@'tools/7zExcludeListDir.txt' boa_c2.pk3 *"]
 				},
 				{
@@ -97,8 +97,8 @@
 			"sources": [
 				{
 					"type": "archive",
-					"url": "https://github.com/FluidSynth/fluidsynth/archive/v1.1.9.tar.gz",
-					"sha256": "dd6321e13a7c875ef3032644bd3197e84b3d24928e2379bc8066b7cace7bd410"
+					"url": "https://github.com/FluidSynth/fluidsynth/archive/v1.1.11.tar.gz",
+					"sha256": "da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8"
 				}
 			]
 		},
@@ -111,12 +111,12 @@
 			"sources": [
 				{
 					"type": "archive",
-					"url": "https://github.com/coelckers/gzdoom/archive/g3.3.1.tar.gz",
-					"sha256": "e33ff4f898bb5abd15371cccbfa5324c65b86776b21ccf35676c3ca7df326e28"
+					"url": "https://github.com/coelckers/gzdoom/archive/g3.4.1.tar.gz",
+					"sha256": "295a006417a13c1996c89d9ebf87457788371a9e2576dbcffc04a55576e300f7"
 				},
 				{
 					"type": "file",
-					"url": "https://github.com/coelckers/gzdoom/raw/g3.2.5/soundfont/gzdoom.sf2",
+					"url": "https://github.com/coelckers/gzdoom/raw/g3.4.1/soundfont/gzdoom.sf2",
 					"sha256": "fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869"
 				},
 				{
@@ -126,7 +126,7 @@
 				}
 			],
 			"post-install": [
-                "install -Dm 644 gzdoom.sf2 /app/share/sounds/sf2/gzdoom.sf2",
+				"install -Dm 644 gzdoom.sf2 /app/share/sounds/sf2/gzdoom.sf2",
 				"install -Dm 644 gzdoom.sh /app/bin/gzdoom.sh",
 				"chmod +x /app/bin/gzdoom.sh"
 			]


### PR DESCRIPTION
This also updates Fluidsynth to version 1.1.11 (follow-up of https://github.com/flathub/io.github.FreeDM/pull/1).

Space indentation was also converted to tabs, and the non-existent `comment` property was replaced with a "JSON comment" of sorts (while JSON doesn't allow comments, Flatpak still seems to accept them).